### PR TITLE
Added the new DQ_SerialManipulatorMDH() Class #35

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ endif()
         src/robot_modeling/DQ_SerialManipulator_py.cpp
         cpp/src/robot_modeling/DQ_SerialManipulatorDH.cpp
         src/robot_modeling/DQ_SerialManipulatorDH_py.cpp
+        cpp/src/robot_modeling/DQ_SerialManipulatorMDH.cpp
+        src/robot_modeling/DQ_SerialManipulatorMDH_py.cpp
         cpp/src/robot_modeling/DQ_SerialManipulatorDenso.cpp
         src/robot_modeling/DQ_SerialManipulatorDenso_py.cpp
         cpp/src/robot_modeling/DQ_MobileBase.cpp

--- a/src/dqrobotics_module.cpp
+++ b/src/dqrobotics_module.cpp
@@ -80,6 +80,9 @@ PYBIND11_MODULE(_dqrobotics, m) {
 
     //DQ_SerialManipulatorDH
     init_DQ_SerialManipulatorDH_py(robot_modeling);
+    
+    //DQ_SerialManipulatorMDH
+    init_DQ_SerialManipulatorMDH_py(robot_modeling);
 
     //DQ_SerialManipulatorDenso
     init_DQ_SerialManipulatorDenso_py(robot_modeling);

--- a/src/dqrobotics_module.h
+++ b/src/dqrobotics_module.h
@@ -39,6 +39,7 @@ namespace py = pybind11;
 #include <dqrobotics/robot_modeling/DQ_Kinematics.h>
 #include <dqrobotics/robot_modeling/DQ_SerialManipulator.h>
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorDH.h>
+#include <dqrobotics/robot_modeling/DQ_SerialManipulatorMDH.h>
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorDenso.h>
 #include <dqrobotics/robot_modeling/DQ_MobileBase.h>
 #include <dqrobotics/robot_modeling/DQ_HolonomicBase.h>
@@ -82,6 +83,7 @@ void init_DQ_Math_py(py::module& m);
 void init_DQ_Kinematics_py(py::module& m);
 void init_DQ_SerialManipulator_py(py::module& m);
 void init_DQ_SerialManipulatorDH_py(py::module& m);
+void init_DQ_SerialManipulatorMDH_py(py::module& m);
 void init_DQ_SerialManipulatorDenso_py(py::module& m);
 void init_DQ_MobileBase_py(py::module& m);
 void init_DQ_HolonomicBase_py(py::module& m);

--- a/src/robot_modeling/DQ_SerialManipulatorMDH_py.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH_py.cpp
@@ -1,0 +1,47 @@
+/**
+(C) Copyright 2020 DQ Robotics Developers
+
+This file is part of DQ Robotics.
+
+    DQ Robotics is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    DQ Robotics is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+
+Contributors:
+- Juan Jose Quiroz Omana -  juanjqo@g.ecc.u-tokyo.ac.jp
+*/
+
+#include "../dqrobotics_module.h"
+
+void init_DQ_SerialManipulatorMDH_py(py::module& m)
+{
+    /***************************************************
+    *  DQ SerialManipulatorMDH
+    * **************************************************/
+    py::class_<DQ_SerialManipulatorMDH,DQ_SerialManipulator> dqserialmanipulatormdh_py(m, "DQ_SerialManipulatorMDH");
+    dqserialmanipulatormdh_py.def(py::init<MatrixXd>());
+
+    ///Methods
+    //Concrete
+    dqserialmanipulatormdh_py.def("get_thetas",  &DQ_SerialManipulatorMDH::get_thetas, "Retrieves the vector of thetas.");
+    dqserialmanipulatormdh_py.def("get_ds",      &DQ_SerialManipulatorMDH::get_ds,     "Retrieves the vector of ds.");
+    dqserialmanipulatormdh_py.def("get_as",      &DQ_SerialManipulatorMDH::get_as,     "Retrieves the vector of as.");
+    dqserialmanipulatormdh_py.def("get_alphas",  &DQ_SerialManipulatorMDH::get_alphas, "Retrieves the vector of alphas.");
+    dqserialmanipulatormdh_py.def("get_types",   &DQ_SerialManipulatorMDH::get_types,  "Retrieves the vector of types.");
+
+    dqserialmanipulatormdh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorMDH::*)(const VectorXd&, const VectorXd&, const int&) const)&DQ_SerialManipulatorMDH::pose_jacobian_derivative, "Returns the pose Jacobian derivative");
+    dqserialmanipulatormdh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorMDH::*)(const VectorXd&, const VectorXd&) const)&DQ_SerialManipulatorMDH::pose_jacobian_derivative,             "Returns the pose Jacobian derivative");
+
+    //Overrides from DQ_SerialManipulator
+    dqserialmanipulatormdh_py.def("raw_pose_jacobian",  (MatrixXd (DQ_SerialManipulatorMDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorMDH::raw_pose_jacobian, "Retrieves the raw pose Jacobian.");
+    dqserialmanipulatormdh_py.def("raw_fkm",            (DQ (DQ_SerialManipulatorMDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorMDH::raw_fkm,                 "Retrieves the raw FKM.");
+}


### PR DESCRIPTION
Hi @mmmarinho,

I included the new DQ_SerialManipulatorMDH() in Python. This version requires the C++ implementation of [the Pull request: Added the new DQ_SerialManipulatorMDH() Class #35](https://github.com/dqrobotics/cpp/pull/35)

I implemented two examples using the FrankaEmikaPanda serial manipulator and the Stanford serial manipulator. Both robots are modeled using both classes (using DH and MDH).

Examples:

```
import os
import sys
import numpy as np
from math import pi
from numpy import linalg as LA

build_path = os.path.abspath(__file__+'/../..')+'/python/build'
sys.path.insert(0,build_path)
from dqrobotics import*
from dqrobotics.robot_modeling import DQ_SerialManipulatorDH
from dqrobotics.robot_modeling import DQ_SerialManipulatorMDH

def FrankaEmikaPandaDH():
    #Standard DH model
    franka_DH_theta = np.array([0, 0, 0, 0, 0, 0, 0])
    franka_DH_d = np.array([0.333, 0, 3.16e-1, 0, 3.84e-1, 0, 1.07e-1])
    franka_DH_a = np.array([0, 0, 8.25e-2, -8.25e-2, 0, 8.8e-2, 0])
    franka_DH_alpha = np.array([-pi/2, pi/2, pi/2, -pi/2, pi/2, pi/2, 0])
    franka_DH_type =  np.array([0,0,0,0,0,0,0])
    franka_DH_matrix = np.array([franka_DH_theta, franka_DH_d, franka_DH_a, franka_DH_alpha, franka_DH_type])
    frankaDH = DQ_SerialManipulatorDH(franka_DH_matrix)
    return frankaDH

def FrankaEmikaPandaMDH():

    # Modified DH model
    franka_DH_theta = np.array([0, 0, 0, 0, 0, 0, 0])
    franka_DH_d = np.array([0.333, 0, 3.16e-1, 0, 3.84e-1, 0, 0])
    franka_DH_a = np.array([0, 0, 0, 8.25e-2, -8.25e-2, 0, 8.8e-2])
    franka_DH_alpha = np.array([0, -pi / 2, pi / 2, pi / 2, -pi / 2, pi / 2, pi / 2])
    franka_DH_type =  np.array([0,0,0,0,0,0,0])
    franka_DH_matrix = np.array([franka_DH_theta, franka_DH_d, franka_DH_a, franka_DH_alpha, franka_DH_type])
    frankaMDH = DQ_SerialManipulatorMDH(franka_DH_matrix)
    frankaMDH.set_effector(1 + DQ.E * 0.5 * DQ.k * 1.07e-1)
    return frankaMDH

frankaDH = FrankaEmikaPandaDH()
frankaMDH = FrankaEmikaPandaMDH()
q = np.random.rand(7)
q_dot = np.random.rand(7)
xDH = frankaDH.fkm(q)
xMDH = frankaMDH.fkm(q)
Jdh = frankaDH.pose_jacobian(q)
Jmdh = frankaMDH.pose_jacobian(q)
Jdh_dot = frankaDH.pose_jacobian_derivative(q, q_dot)
Jmdh_dot = haminus8(frankaMDH.get_effector())@frankaMDH.pose_jacobian_derivative(q, q_dot)
print('Error in fkm')
print(xDH-xMDH)
print('Error in pose jacobian: ', LA.norm(Jdh-Jmdh, 'fro'))
#print(Jdh-Jmdh)
print('Error in pose jacobian derivative',LA.norm(Jdh_dot-Jmdh_dot, 'fro'))
#print(Jdh_dot-Jmdh_dot)
```

Results:

```
Error in fkm
0
Error in pose jacobian:  5.477744755553998e-16
Error in pose jacobian derivative 6.420696527768584e-16
Process finished with exit code 0
```


Example 2


```
import os
import sys
import numpy as np
from math import pi
from numpy import linalg as LA

build_path = os.path.abspath(__file__+'/../..')+'/python/build'
sys.path.insert(0,build_path)
from dqrobotics import*
from dqrobotics.robot_modeling import DQ_SerialManipulatorDH
from dqrobotics.robot_modeling import DQ_SerialManipulatorMDH

def StanfordManipulatorDH():
    #Standard DH model
    d2 = 0.4
    d3 = 0.1
    d6 = 0.3
    robot_DH_theta = np.array([0, 0, 0, 0, 0, 0])
    robot_DH_d = np.array([0,d2,d3,0,0,d6])
    robot_DH_a = np.array([0, 0, 0, 0 ,0 ,0])
    robot_DH_alpha = np.array([-pi/2, pi/2, 0,-pi/2,pi/2,0])
    robot_DH_type =  np.array([0,0,1,0,0,0])
    robot_DH_matrix = np.array([robot_DH_theta, robot_DH_d, robot_DH_a, robot_DH_alpha, robot_DH_type])
    robotDH = DQ_SerialManipulatorDH(robot_DH_matrix)
    return robotDH

def StanfordManipulatorMDH():
    # Modified DH model
    d2 = 0.4
    d3 = 0.1
    d6 = 0.3
    robot_DH_theta = np.array([0, 0, 0, 0, 0, 0])
    robot_DH_d = np.array([0,d2,d3,0,0,0])
    robot_DH_a = np.array([0, 0, 0, 0, 0, 0])
    robot_DH_alpha = np.array([0,-pi/2, pi/2, 0,-pi/2,pi/2])
    robot_DH_type =  np.array([0,0,1,0,0,0])
    robot_DH_matrix = np.array([robot_DH_theta, robot_DH_d, robot_DH_a, robot_DH_alpha, robot_DH_type])
    robotMDH = DQ_SerialManipulatorMDH(robot_DH_matrix)
    robotMDH.set_effector(1+DQ.E*0.5*DQ.k*d6)
    return robotMDH

robotDH = StanfordManipulatorDH()
robotMDH = StanfordManipulatorMDH()
q = np.random.rand(6)
q_dot = np.random.rand(6)
xDH = robotDH.fkm(q)
xMDH = robotMDH.fkm(q)
Jdh = robotDH.pose_jacobian(q)
Jmdh = robotMDH.pose_jacobian(q)
Jdh_dot = robotDH.pose_jacobian_derivative(q, q_dot)
Jmdh_dot = haminus8(robotMDH.get_effector())@robotMDH.pose_jacobian_derivative(q, q_dot)
print('Error in fkm')
print(xDH-xMDH)
print('Error in pose jacobian: ', LA.norm(Jdh-Jmdh, 'fro'))
#print(Jdh-Jmdh)
print('Error in pose jacobian derivative',LA.norm(Jdh_dot-Jmdh_dot, 'fro'))
#print(Jdh_dot-Jmdh_dot)
```

Results:

```
Error in fkm
0
Error in pose jacobian:  5.056949529391881e-16
Error in pose jacobian derivative 3.9384335993085515e-16

Process finished with exit code 0
```