### PR TITLE
[DQ_Kinematics_py.cpp] Added the line_to_line_angle_residual method.

### DIFF
--- a/src/robot_modeling/DQ_Kinematics_py.cpp
+++ b/src/robot_modeling/DQ_Kinematics_py.cpp
@@ -60,5 +60,6 @@ void init_DQ_Kinematics_py(py::module& m)
     dqkinematics_py.def_static("plane_to_point_distance_jacobian", &DQ_Kinematics::plane_to_point_distance_jacobian,"Returns the robot plane to point distance Jacobian");
     dqkinematics_py.def_static("plane_to_point_residual",          &DQ_Kinematics::plane_to_point_residual,"Returns the robot plane to point residual");
     dqkinematics_py.def_static("line_to_line_angle_jacobian",      &DQ_Kinematics::line_to_line_angle_jacobian,"Returns the line to line angle Jacobian");
+    dqkinematics_py.def_static("line_to_line_angle_residual",      &DQ_Kinematics::line_to_line_angle_residual,"Returns the line to line angle residual");
     dqkinematics_py.def_static("line_segment_to_line_segment_distance_jacobian", &DQ_Kinematics::line_segment_to_line_segment_distance_jacobian, "Returns the line segment to line segment distance Jacobian");
 }


### PR DESCRIPTION
@dqrobotics/developers 

Hi @mmmarinho , 

This PR adds the method `line_to_line_angle_residual` in `DQ_Kinematics_py.cpp`:

```python
dqkinematics_py.def_static("line_to_line_angle_residual",      &DQ_Kinematics::line_to_line_angle_residual,"Returns the line to line angle residual");
```

I added an example [here.](https://github.com/dqrobotics/python-examples/pull/5)

Best regards, 

Juancho


