### PR TITLE
Added the pose_jacobian_derivative method 

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -115,6 +115,7 @@ jobs:
         python DQ_SerialManipulatorMDH_test.py
         python cpp_issues.py
         python python_issues.py
+        python DQ_Kinematics_pose_jacobian_derivative_tests.py
         cd ..
     - name: Rename wheel (Ubuntu Only)
       if: matrix.os == 'ubuntu-latest'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ endif()
         cpp/src/robots/ComauSmartSixRobot.cpp
         cpp/src/robots/KukaLw4Robot.cpp
         cpp/src/robots/KukaYoubotRobot.cpp
+        cpp/src/robots/FrankaEmikaPandaRobot.cpp
 
         #interfaces/vrep
         interfaces/cpp-interface-vrep/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp

--- a/src/dqrobotics_module.cpp
+++ b/src/dqrobotics_module.cpp
@@ -67,6 +67,10 @@ PYBIND11_MODULE(_dqrobotics, m) {
     py::class_<KukaYoubotRobot> kukayoubotrobot_py(robots_py, "KukaYoubotRobot");
     kukayoubotrobot_py.def_static("kinematics",&KukaYoubotRobot::kinematics,"Returns the kinematics of the KukaYoubotRobot");
 
+    //#include <dqrobotics/robots/FrankaEmikaPandaRobot.h>
+    py::class_<FrankaEmikaPandaRobot> frankaemikapandarobot_py(robots_py, "FrankaEmikaPandaRobot");
+    frankaemikapandarobot_py.def_static("kinematics",&FrankaEmikaPandaRobot::kinematics,"Returns the kinematics of the FrankaEmikaPandaRobot");
+
     /*****************************************************
      *  Robot Modeling <dqrobotics/robot_modeling/...>
      * **************************************************/

--- a/src/dqrobotics_module.h
+++ b/src/dqrobotics_module.h
@@ -61,6 +61,7 @@ namespace py = pybind11;
 #include <dqrobotics/robots/ComauSmartSixRobot.h>
 #include <dqrobotics/robots/KukaLw4Robot.h>
 #include <dqrobotics/robots/KukaYoubotRobot.h>
+#include <dqrobotics/robots/FrankaEmikaPandaRobot.h>
 
 #include <dqrobotics/interfaces/vrep/DQ_VrepInterface.h>
 #include <dqrobotics/interfaces/vrep/DQ_VrepRobot.h>

--- a/src/robot_modeling/DQ_DifferentialDriveRobot_py.cpp
+++ b/src/robot_modeling/DQ_DifferentialDriveRobot_py.cpp
@@ -36,4 +36,8 @@ void init_DQ_DifferentialDriveRobot_py(py::module& m)
     dqdifferentialdriverobot_py.def("constraint_jacobian", &DQ_DifferentialDriveRobot::constraint_jacobian, "Returns the constraint Jacobian");
     dqdifferentialdriverobot_py.def("pose_jacobian",               (MatrixXd (DQ_DifferentialDriveRobot::*)(const VectorXd&, const int&) const)&DQ_DifferentialDriveRobot::pose_jacobian,"Returns the pose Jacobian");
     dqdifferentialdriverobot_py.def("pose_jacobian",               (MatrixXd (DQ_DifferentialDriveRobot::*)(const VectorXd&) const)&DQ_DifferentialDriveRobot::pose_jacobian,"Returns the pose Jacobian");
+    dqdifferentialdriverobot_py.def("pose_jacobian_derivative",    (MatrixXd (DQ_DifferentialDriveRobot::*)(const VectorXd&, const VectorXd&, const int&) const)&DQ_DifferentialDriveRobot::pose_jacobian_derivative,
+                                                                   "Returns the pose Jacobian derivative");
+    dqdifferentialdriverobot_py.def("pose_jacobian_derivative",    (MatrixXd (DQ_DifferentialDriveRobot::*)(const VectorXd&, const VectorXd&) const)&DQ_DifferentialDriveRobot::pose_jacobian_derivative,
+                                                                   "Returns the pose Jacobian derivative");
 }

--- a/src/robot_modeling/DQ_HolonomicBase_py.cpp
+++ b/src/robot_modeling/DQ_HolonomicBase_py.cpp
@@ -37,7 +37,12 @@ void init_DQ_HolonomicBase_py(py::module& m)
     dqholonomicbase_py.def("fkm",(DQ (DQ_HolonomicBase::*)(const VectorXd&,const int&) const)&DQ_HolonomicBase::fkm,"Gets the fkm.");
     dqholonomicbase_py.def("pose_jacobian",               (MatrixXd (DQ_HolonomicBase::*)(const VectorXd&, const int&) const)&DQ_HolonomicBase::pose_jacobian,"Returns the pose Jacobian");
     dqholonomicbase_py.def("pose_jacobian",               (MatrixXd (DQ_HolonomicBase::*)(const VectorXd&) const)&DQ_HolonomicBase::pose_jacobian,"Returns the pose Jacobian");
+    dqholonomicbase_py.def("pose_jacobian_derivative",    (MatrixXd (DQ_HolonomicBase::*)(const VectorXd&, const VectorXd&) const)&DQ_HolonomicBase::pose_jacobian_derivative,
+                                                           "Returns the pose Jacobian derivative");
+    dqholonomicbase_py.def("pose_jacobian_derivative",    (MatrixXd (DQ_HolonomicBase::*)(const VectorXd&, const VectorXd&, const int&) const)&DQ_HolonomicBase::pose_jacobian_derivative,
+                                                           "Returns the pose Jacobian derivative");
     dqholonomicbase_py.def("get_dim_configuration_space",&DQ_HolonomicBase::get_dim_configuration_space,"Returns the size of the configuration space");
     dqholonomicbase_py.def("raw_fkm",                    &DQ_HolonomicBase::raw_fkm,"Returns the raw fkm");
-    dqholonomicbase_py.def("raw_pose_jacobian",          &DQ_HolonomicBase::raw_pose_jacobian,"Return the raw ose Jacobian");
+    dqholonomicbase_py.def("raw_pose_jacobian",          &DQ_HolonomicBase::raw_pose_jacobian,"Return the raw pose Jacobian");
+    dqholonomicbase_py.def("raw_pose_jacobian_derivative", &DQ_HolonomicBase::raw_pose_jacobian_derivative,"Return the raw pose Jacobian derivative");
 }

--- a/src/robot_modeling/DQ_SerialManipulatorDH_py.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDH_py.cpp
@@ -42,9 +42,6 @@ void init_DQ_SerialManipulatorDH_py(py::module& m)
     dqserialmanipulatordh_py.def("get_alphas",  &DQ_SerialManipulatorDH::get_alphas, "Retrieves the vector of alphas.");
     dqserialmanipulatordh_py.def("get_types",   &DQ_SerialManipulatorDH::get_types,  "Retrieves the vector of types.");
 
-    //dqserialmanipulatordh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorDH::*)(const VectorXd&, const VectorXd&, const int&) const)&DQ_SerialManipulatorDH::pose_jacobian_derivative, "Returns the pose Jacobian derivative");
-    //dqserialmanipulatordh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorDH::*)(const VectorXd&, const VectorXd&) const)&DQ_SerialManipulatorDH::pose_jacobian_derivative,             "Returns the pose Jacobian derivative");
-
     //Overrides from DQ_SerialManipulator
     dqserialmanipulatordh_py.def("raw_pose_jacobian",  (MatrixXd (DQ_SerialManipulatorDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorDH::raw_pose_jacobian, "Retrieves the raw pose Jacobian.");
     dqserialmanipulatordh_py.def("raw_fkm",            (DQ (DQ_SerialManipulatorDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorDH::raw_fkm,                 "Retrieves the raw FKM.");

--- a/src/robot_modeling/DQ_SerialManipulatorDH_py.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDH_py.cpp
@@ -42,10 +42,12 @@ void init_DQ_SerialManipulatorDH_py(py::module& m)
     dqserialmanipulatordh_py.def("get_alphas",  &DQ_SerialManipulatorDH::get_alphas, "Retrieves the vector of alphas.");
     dqserialmanipulatordh_py.def("get_types",   &DQ_SerialManipulatorDH::get_types,  "Retrieves the vector of types.");
 
-    dqserialmanipulatordh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorDH::*)(const VectorXd&, const VectorXd&, const int&) const)&DQ_SerialManipulatorDH::pose_jacobian_derivative, "Returns the pose Jacobian derivative");
-    dqserialmanipulatordh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorDH::*)(const VectorXd&, const VectorXd&) const)&DQ_SerialManipulatorDH::pose_jacobian_derivative,             "Returns the pose Jacobian derivative");
+    //dqserialmanipulatordh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorDH::*)(const VectorXd&, const VectorXd&, const int&) const)&DQ_SerialManipulatorDH::pose_jacobian_derivative, "Returns the pose Jacobian derivative");
+    //dqserialmanipulatordh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorDH::*)(const VectorXd&, const VectorXd&) const)&DQ_SerialManipulatorDH::pose_jacobian_derivative,             "Returns the pose Jacobian derivative");
 
     //Overrides from DQ_SerialManipulator
     dqserialmanipulatordh_py.def("raw_pose_jacobian",  (MatrixXd (DQ_SerialManipulatorDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorDH::raw_pose_jacobian, "Retrieves the raw pose Jacobian.");
     dqserialmanipulatordh_py.def("raw_fkm",            (DQ (DQ_SerialManipulatorDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorDH::raw_fkm,                 "Retrieves the raw FKM.");
+    dqserialmanipulatordh_py.def("raw_pose_jacobian_derivative",(MatrixXd (DQ_SerialManipulatorDH::*)(const VectorXd&, const VectorXd&, const int&) const)
+                                                                &DQ_SerialManipulatorDH::raw_pose_jacobian_derivative, "Retrieves the raw pose Jacobian derivative.");
 }

--- a/src/robot_modeling/DQ_SerialManipulatorDenso_py.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDenso_py.cpp
@@ -46,4 +46,7 @@ void init_DQ_SerialManipulatorDenso_py(py::module& m)
     //Overrides from DQ_SerialManipulator
     dqserialmanipulatordh_py.def("raw_pose_jacobian",  (MatrixXd (DQ_SerialManipulatorDenso::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorDenso::raw_pose_jacobian, "Retrieves the raw pose Jacobian.");
     dqserialmanipulatordh_py.def("raw_fkm",            (DQ (DQ_SerialManipulatorDenso::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorDenso::raw_fkm,                 "Retrieves the raw FKM.");
+    dqserialmanipulatordh_py.def("raw_pose_jacobian_derivative",(MatrixXd (DQ_SerialManipulator::*)(const VectorXd&, const VectorXd&, const int&) const)
+                                                                &DQ_SerialManipulator::raw_pose_jacobian_derivative,
+                                                                "Retrieves the raw pose Jacobian derivative.");
 }

--- a/src/robot_modeling/DQ_SerialManipulatorDenso_py.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorDenso_py.cpp
@@ -46,7 +46,6 @@ void init_DQ_SerialManipulatorDenso_py(py::module& m)
     //Overrides from DQ_SerialManipulator
     dqserialmanipulatordh_py.def("raw_pose_jacobian",  (MatrixXd (DQ_SerialManipulatorDenso::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorDenso::raw_pose_jacobian, "Retrieves the raw pose Jacobian.");
     dqserialmanipulatordh_py.def("raw_fkm",            (DQ (DQ_SerialManipulatorDenso::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorDenso::raw_fkm,                 "Retrieves the raw FKM.");
-    dqserialmanipulatordh_py.def("raw_pose_jacobian_derivative",(MatrixXd (DQ_SerialManipulator::*)(const VectorXd&, const VectorXd&, const int&) const)
-                                                                &DQ_SerialManipulator::raw_pose_jacobian_derivative,
-                                                                "Retrieves the raw pose Jacobian derivative.");
+    dqserialmanipulatordh_py.def("raw_pose_jacobian_derivative",(MatrixXd (DQ_SerialManipulatorDenso::*)(const VectorXd&, const VectorXd&, const int&) const)
+                                                                &DQ_SerialManipulatorDenso::raw_pose_jacobian_derivative, "Retrieves the raw pose Jacobian derivative.");
 }

--- a/src/robot_modeling/DQ_SerialManipulatorMDH_py.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH_py.cpp
@@ -42,9 +42,6 @@ void init_DQ_SerialManipulatorMDH_py(py::module& m)
     dqserialmanipulatormdh_py.def("get_alphas",  &DQ_SerialManipulatorMDH::get_alphas, "Retrieves the vector of alphas.");
     dqserialmanipulatormdh_py.def("get_types",   &DQ_SerialManipulatorMDH::get_types,  "Retrieves the vector of types.");
 
-    dqserialmanipulatormdh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorMDH::*)(const VectorXd&, const VectorXd&, const int&) const)&DQ_SerialManipulatorMDH::pose_jacobian_derivative, "Returns the pose Jacobian derivative");
-    dqserialmanipulatormdh_py.def("pose_jacobian_derivative", (MatrixXd (DQ_SerialManipulatorMDH::*)(const VectorXd&, const VectorXd&) const)&DQ_SerialManipulatorMDH::pose_jacobian_derivative,             "Returns the pose Jacobian derivative");
-
     //Overrides from DQ_SerialManipulator
     dqserialmanipulatormdh_py.def("raw_pose_jacobian",  (MatrixXd (DQ_SerialManipulatorMDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorMDH::raw_pose_jacobian, "Retrieves the raw pose Jacobian.");
     dqserialmanipulatormdh_py.def("raw_fkm",            (DQ (DQ_SerialManipulatorMDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorMDH::raw_fkm,                 "Retrieves the raw FKM.");

--- a/src/robot_modeling/DQ_SerialManipulatorMDH_py.cpp
+++ b/src/robot_modeling/DQ_SerialManipulatorMDH_py.cpp
@@ -48,4 +48,6 @@ void init_DQ_SerialManipulatorMDH_py(py::module& m)
     //Overrides from DQ_SerialManipulator
     dqserialmanipulatormdh_py.def("raw_pose_jacobian",  (MatrixXd (DQ_SerialManipulatorMDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorMDH::raw_pose_jacobian, "Retrieves the raw pose Jacobian.");
     dqserialmanipulatormdh_py.def("raw_fkm",            (DQ (DQ_SerialManipulatorMDH::*)(const VectorXd&, const int&) const)&DQ_SerialManipulatorMDH::raw_fkm,                 "Retrieves the raw FKM.");
+    dqserialmanipulatormdh_py.def("raw_pose_jacobian_derivative",(MatrixXd (DQ_SerialManipulatorMDH::*)(const VectorXd&, const VectorXd&, const int&) const)
+                                                                &DQ_SerialManipulatorMDH::raw_pose_jacobian_derivative, "Retrieves the raw pose Jacobian derivative.");
 }

--- a/src/robot_modeling/DQ_SerialManipulator_py.cpp
+++ b/src/robot_modeling/DQ_SerialManipulator_py.cpp
@@ -50,6 +50,9 @@ void init_DQ_SerialManipulator_py(py::module& m)
     //Virtual
     dqserialmanipulator_py.def("raw_fkm",                     (DQ (DQ_SerialManipulator::*)(const VectorXd&) const)&DQ_SerialManipulator::raw_fkm,"Gets the raw fkm.");
     dqserialmanipulator_py.def("raw_pose_jacobian",           (MatrixXd (DQ_SerialManipulator::*)(const VectorXd&) const)&DQ_SerialManipulator::raw_pose_jacobian,"Returns the pose Jacobian without base or effector transformation");
+    dqserialmanipulator_py.def("raw_pose_jacobian_derivative",(MatrixXd (DQ_SerialManipulator::*)(const VectorXd&, const VectorXd&) const)
+                                                               &DQ_SerialManipulator::raw_pose_jacobian_derivative,
+                                                               "Returns the pose Jacobian derivative without base or effector transformation");
 
     //Overrides from DQ_Kinematics
     dqserialmanipulator_py.def("fkm",                         (DQ (DQ_SerialManipulator::*)(const VectorXd&) const)&DQ_SerialManipulator::fkm,"Gets the fkm.");
@@ -59,4 +62,8 @@ void init_DQ_SerialManipulator_py(py::module& m)
 
     dqserialmanipulator_py.def("pose_jacobian",               (MatrixXd (DQ_SerialManipulator::*)(const VectorXd&, const int&) const)&DQ_SerialManipulator::pose_jacobian,"Returns the pose Jacobian");
     dqserialmanipulator_py.def("pose_jacobian",               (MatrixXd (DQ_SerialManipulator::*)(const VectorXd&) const)&DQ_SerialManipulator::pose_jacobian,"Returns the pose Jacobian");
+    dqserialmanipulator_py.def("pose_jacobian_derivative",    (MatrixXd (DQ_SerialManipulator::*)(const VectorXd&, const VectorXd&, const int&) const)
+                                                               &DQ_SerialManipulator::pose_jacobian_derivative,"Returns the pose Jacobian derivative");
+    dqserialmanipulator_py.def("pose_jacobian_derivative",    (MatrixXd (DQ_SerialManipulator::*)(const VectorXd&, const VectorXd&) const)
+                                                               &DQ_SerialManipulator::pose_jacobian_derivative,"Returns the pose Jacobian derivative");
 }

--- a/src/robot_modeling/DQ_SerialWholeBody_py.cpp
+++ b/src/robot_modeling/DQ_SerialWholeBody_py.cpp
@@ -42,4 +42,6 @@ void init_DQ_SerialWholeBody_py(py::module& m)
     dqserialwholebody_py.def("get_chain_as_holonomic_base",&DQ_SerialWholeBody::get_chain_as_holonomic_base, "Returns the DQ_HolonomicBase at a given index of the chain");
     dqserialwholebody_py.def("pose_jacobian",(MatrixXd (DQ_SerialWholeBody::*)(const VectorXd&, const int&) const)&DQ_SerialWholeBody::pose_jacobian,"Returns the pose Jacobian");
     dqserialwholebody_py.def("pose_jacobian",(MatrixXd (DQ_SerialWholeBody::*)(const VectorXd&) const)&DQ_SerialWholeBody::pose_jacobian,"Returns the pose Jacobian");
+    dqserialwholebody_py.def("pose_jacobian_derivative",(MatrixXd (DQ_SerialWholeBody::*)(const VectorXd&, const VectorXd&, const int&) const)&DQ_SerialWholeBody::pose_jacobian_derivative,"Returns the pose Jacobian derivative");
+    dqserialwholebody_py.def("pose_jacobian_derivative",(MatrixXd (DQ_SerialWholeBody::*)(const VectorXd&, const VectorXd&) const)&DQ_SerialWholeBody::pose_jacobian_derivative,"Returns the pose Jacobian derivative");
 }

--- a/src/robot_modeling/DQ_WholeBody_py.cpp
+++ b/src/robot_modeling/DQ_WholeBody_py.cpp
@@ -42,4 +42,6 @@ void init_DQ_WholeBody_py(py::module& m)
     dqwholebody_py.def("get_chain_as_holonomic_base",&DQ_WholeBody::get_chain_as_holonomic_base, "Returns the DQ_HolonomicBase at a given index of the chain");
     dqwholebody_py.def("pose_jacobian",(MatrixXd (DQ_WholeBody::*)(const VectorXd&, const int&) const)&DQ_WholeBody::pose_jacobian,"Returns the pose Jacobian");
     dqwholebody_py.def("pose_jacobian",(MatrixXd (DQ_WholeBody::*)(const VectorXd&) const)&DQ_WholeBody::pose_jacobian,"Returns the pose Jacobian");
+    dqwholebody_py.def("pose_jacobian_derivative",(MatrixXd (DQ_WholeBody::*)(const VectorXd&, const VectorXd&, const int&) const)&DQ_WholeBody::pose_jacobian_derivative,"Returns the pose Jacobian derivative");
+    dqwholebody_py.def("pose_jacobian_derivative",(MatrixXd (DQ_WholeBody::*)(const VectorXd&, const VectorXd&) const)&DQ_WholeBody::pose_jacobian_derivative,"Returns the pose Jacobian derivative");
 }


### PR DESCRIPTION
@dqrobotics/developers 

@mmmarinho 

This PR updates the Python Version of the DQ Robotics with respect to the current version of C++ (Master branch). 

Features:

-  The method pose jacobian derivative is implemented in DQ_HolonomicBase_py, DQ_DifferentialDriveRobot_py, DQ_SerialManipulator_py (and for DH, MDH & Denso), DQ_SerialWholeBody_py and DQ_WholeBody_py.

-  The Franka Emika Panda robot is available now in Python.

I added a test [here](https://github.com/dqrobotics/python-tests/pull/3) to check the accuracy of the pose_jacobian_derivative method with respect to the numerical differentiation based on eight-point central finite differences. 

Best regards, 

Juancho
