### PR TITLE
Static jacobian derivatives

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -123,6 +123,7 @@ jobs:
         python cpp_issues.py
         python python_issues.py
         python DQ_Kinematics_pose_jacobian_derivative_tests.py
+        python DQ_Kinematics_static_jacobian_derivative_tests.py
         cd ..
     - name: Rename wheel (Ubuntu Only)
       if: matrix.os == 'ubuntu-latest'

--- a/src/robot_modeling/DQ_Kinematics_py.cpp
+++ b/src/robot_modeling/DQ_Kinematics_py.cpp
@@ -52,7 +52,6 @@ void init_DQ_Kinematics_py(py::module& m)
     dqkinematics_py.def_static("rotation_jacobian_derivative",     &DQ_Kinematics::rotation_jacobian_derivative,    "Returns the rotation Jacobian derivative");
     dqkinematics_py.def_static("line_jacobian_derivative",         &DQ_Kinematics::line_jacobian_derivative,        "Returns the line Jacobian derivative");
     dqkinematics_py.def_static("plane_jacobian_derivative",        &DQ_Kinematics::plane_jacobian_derivative,       "Returns the plane Jacobian derivative");
-
     dqkinematics_py.def_static("point_to_point_distance_jacobian", &DQ_Kinematics::point_to_point_distance_jacobian,"Returns the robot point to point distance Jacobian");
     dqkinematics_py.def_static("point_to_point_residual",          &DQ_Kinematics::point_to_point_residual,"Returns the robot point to point residual");
     dqkinematics_py.def_static("point_to_line_distance_jacobian",  &DQ_Kinematics::point_to_line_distance_jacobian,"Returns the robot point to line distance Jacobian");

--- a/src/robot_modeling/DQ_Kinematics_py.cpp
+++ b/src/robot_modeling/DQ_Kinematics_py.cpp
@@ -47,6 +47,12 @@ void init_DQ_Kinematics_py(py::module& m)
     dqkinematics_py.def_static("rotation_jacobian",                &DQ_Kinematics::rotation_jacobian,     "Returns the rotation Jacobian");
     dqkinematics_py.def_static("line_jacobian",                    &DQ_Kinematics::line_jacobian,         "Returns the line Jacobian");
     dqkinematics_py.def_static("plane_jacobian",                   &DQ_Kinematics::plane_jacobian,        "Returns the plane Jacobian");
+    dqkinematics_py.def_static("distance_jacobian_derivative",     &DQ_Kinematics::distance_jacobian_derivative,    "Returns the distance Jacobian derivative");
+    dqkinematics_py.def_static("translation_jacobian_derivative",  &DQ_Kinematics::translation_jacobian_derivative, "Returns the translation Jacobian derivative");
+    dqkinematics_py.def_static("rotation_jacobian_derivative",     &DQ_Kinematics::rotation_jacobian_derivative,    "Returns the rotation Jacobian derivative");
+    dqkinematics_py.def_static("line_jacobian_derivative",         &DQ_Kinematics::line_jacobian_derivative,        "Returns the line Jacobian derivative");
+    dqkinematics_py.def_static("plane_jacobian_derivative",        &DQ_Kinematics::plane_jacobian_derivative,       "Returns the plane Jacobian derivative");
+
     dqkinematics_py.def_static("point_to_point_distance_jacobian", &DQ_Kinematics::point_to_point_distance_jacobian,"Returns the robot point to point distance Jacobian");
     dqkinematics_py.def_static("point_to_point_residual",          &DQ_Kinematics::point_to_point_residual,"Returns the robot point to point residual");
     dqkinematics_py.def_static("point_to_line_distance_jacobian",  &DQ_Kinematics::point_to_line_distance_jacobian,"Returns the robot point to line distance Jacobian");


### PR DESCRIPTION
@dqrobotics/developers 

Hi @bvadorno and @mmmarinho 

This PR adds the following static methods to DQ_Kinematics:

```python
dqkinematics_py.def_static("distance_jacobian_derivative",     &DQ_Kinematics::distance_jacobian_derivative,    "Returns the distance Jacobian derivative");
dqkinematics_py.def_static("translation_jacobian_derivative",  &DQ_Kinematics::translation_jacobian_derivative, "Returns the translation Jacobian derivative");
dqkinematics_py.def_static("rotation_jacobian_derivative",     &DQ_Kinematics::rotation_jacobian_derivative,    "Returns the rotation Jacobian derivative");
dqkinematics_py.def_static("line_jacobian_derivative",         &DQ_Kinematics::line_jacobian_derivative,        "Returns the line Jacobian derivative");
dqkinematics_py.def_static("plane_jacobian_derivative",        &DQ_Kinematics::plane_jacobian_derivative,       "Returns the plane Jacobian derivative");
```


Requirements: 

- [DQ Robotics C++ PR/53](https://github.com/dqrobotics/cpp/pull/53)

Tests:

- [Python tests PR/4](https://github.com/dqrobotics/python-tests/pull/4)

Best regards, 

Juancho