### PR TITLE
Fix `line_to_line_residual` def in `DQ_Kinematics_py.cpp`

### DIFF
--- a/src/robot_modeling/DQ_Kinematics_py.cpp
+++ b/src/robot_modeling/DQ_Kinematics_py.cpp
@@ -61,7 +61,7 @@ void init_DQ_Kinematics_py(py::module& m)
     dqkinematics_py.def_static("line_to_point_distance_jacobian",  &DQ_Kinematics::line_to_point_distance_jacobian,"Returns the robot line to point distance Jacobian");
     dqkinematics_py.def_static("line_to_point_residual",           &DQ_Kinematics::line_to_point_residual,"Returns the robot line to point residual");
     dqkinematics_py.def_static("line_to_line_distance_jacobian",   &DQ_Kinematics::line_to_line_distance_jacobian,"Returns the robot line to line distance Jacobian");
-    dqkinematics_py.def_static("line_to_point_residual",           &DQ_Kinematics::line_to_point_residual,        "Returns the robot line to line residual");
+    dqkinematics_py.def_static("line_to_line_residual",           &DQ_Kinematics::line_to_line_residual,        "Returns the robot line to line residual");
     dqkinematics_py.def_static("plane_to_point_distance_jacobian", &DQ_Kinematics::plane_to_point_distance_jacobian,"Returns the robot plane to point distance Jacobian");
     dqkinematics_py.def_static("plane_to_point_residual",          &DQ_Kinematics::plane_to_point_residual,"Returns the robot plane to point residual");
     dqkinematics_py.def_static("line_to_line_angle_jacobian",      &DQ_Kinematics::line_to_line_angle_jacobian,"Returns the line to line angle Jacobian");


### PR DESCRIPTION
~Request for bug fix in dqrobotics python for DQ_Kinematic reference to line_to_line_residual fucntion~

_Edit by @mmmarinho for clarity:_

# Bug & Cause

There is no `line_to_line_residual` accessible through the Python API. See #48 

# Fix

The two references to `line_to_point_residual` in L64, shown below, must be replaced by `line_to_line_residual`.

https://github.com/dqrobotics/python/blob/413595ee8c1964a7b960c687c19e4f9603d17c35/src/robot_modeling/DQ_Kinematics_py.cpp#L64