### PR TITLE
Added the method wait_for_simulation_step_to_end() to fix #50

### DIFF
--- a/src/interfaces/vrep/DQ_VrepInterface_py.cpp
+++ b/src/interfaces/vrep/DQ_VrepInterface_py.cpp
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2019 DQ Robotics Developers
+(C) Copyright 2019-2023 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -17,7 +17,11 @@ This file is part of DQ Robotics.
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
 
 Contributors:
-- Murilo M. Marinho (murilomarinho@ieee.org)
+1.  Murilo M. Marinho        (murilomarinho@ieee.org)
+        - Initial implementation.
+
+2.  Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+        -Added the method wait_for_simulation_step_to_end()
 */
 
 #include "../../dqrobotics_module.h"
@@ -72,6 +76,9 @@ void init_DQ_VrepInterface_py(py::module& m)
 
     //void trigger_next_simulation_step();
     dqvrepinterface_py.def("trigger_next_simulation_step", &DQ_VrepInterface::trigger_next_simulation_step, "Sends a synchronization trigger signal to the server.");
+
+    //void wait_for_simulation_step_to_end(); 
+    dqvrepinterface_py.def("wait_for_simulation_step_to_end", &DQ_VrepInterface::wait_for_simulation_step_to_end, "Returns the time needed for a command to be sent to the server, executed, and sent back.");
 
     //dqvrepinterface_py.def("get_object_handle", &DQ_VrepInterface::get_object_handle,"Gets an object handle");
     //dqvrepinterface_py.def("get_object_handles",&DQ_VrepInterface::get_object_handles,"Get object handles");

--- a/src/interfaces/vrep/DQ_VrepInterface_py.cpp
+++ b/src/interfaces/vrep/DQ_VrepInterface_py.cpp
@@ -78,7 +78,7 @@ void init_DQ_VrepInterface_py(py::module& m)
     dqvrepinterface_py.def("trigger_next_simulation_step", &DQ_VrepInterface::trigger_next_simulation_step, "Sends a synchronization trigger signal to the server.");
 
     //void wait_for_simulation_step_to_end(); 
-    dqvrepinterface_py.def("wait_for_simulation_step_to_end", &DQ_VrepInterface::wait_for_simulation_step_to_end, "Returns the time needed for a command to be sent to the server, executed, and sent back.");
+    dqvrepinterface_py.def("wait_for_simulation_step_to_end", &DQ_VrepInterface::wait_for_simulation_step_to_end, "Waits until the simulation step is finished.");
 
     //dqvrepinterface_py.def("get_object_handle", &DQ_VrepInterface::get_object_handle,"Gets an object handle");
     //dqvrepinterface_py.def("get_object_handles",&DQ_VrepInterface::get_object_handles,"Get object handles");


### PR DESCRIPTION
![](https://img.shields.io/badge/Tests-developer%20workflow-orange)![](https://img.shields.io/badge/Ubuntu%2020.04.5%20LTS%20(x64)-passing-passing)

![Static Badge](https://img.shields.io/badge/status-Ready_for_review-passing)

@dqrobotics/developers 

Hi @mmmarinho, 

This PR adds the method wait_for_simulation_step_to_end() to fix #50

- [x] Added [example](https://github.com/dqrobotics/python-examples/pull/8) in dqrobotics/python-examples.

Best regards, 

Juancho

### About the test:

The synchronous mode is tested, comparing the height of a dynamic object in free fall with the expected height after 0.25 s in the simulation time. The expected height is computed as y(t) = y_0 + 0.5 * `g` * t^2, where `g=-9.81`, t= elapsed simulation time. To ensure the synchrony (in the synchronous mode), the method `wait_for_simulation_step_to_end()` is paramount.

```python
        for i in range(0, 6):
            print(i)
            t = i * time_simulation_step
            y_sim = vi.get_object_pose("/Sphere").translation().vec3()[2]
            y_est = y_0 - 0.5 * 9.81 * pow(t, 2)
            vi.trigger_next_simulation_step()
            vi.wait_for_simulation_step_to_end()
```
#### Results (synchronized)

```shell
Elapsed time:  0.25
Estimated height:  0.6934374999999999 Measured height:  0.6873062252998352
```

#### Results without `wait_for_simulation_step_to_end()`  

```python
        for i in range(0, 6):
            print(i)
            t = i * time_simulation_step
            y_sim = vi.get_object_pose("/Sphere").translation().vec3()[2]
            y_est = y_0 - 0.5 * 9.81 * pow(t, 2)
            vi.trigger_next_simulation_step()
            #vi.wait_for_simulation_step_to_end()
```
####      (Not synchronized)
```shell
Elapsed time:  0.25
Estimated height:  0.6934374999999999 Measured height:  0.798895001411438
```

![simulation_scene](https://github.com/dqrobotics/python/assets/23158313/11cef837-acbf-459f-bbd0-ee99d7634370)

### Note:

During my local tests, the synchronous mode worked for only some setups.  This means that in some cases, the method `wait_for_simulation_step_to_end()`, which calls the blocking function `simxGetPingTime()` of the Legacy Remote API didn't ensure the synchrony between the simulation and the script. 

| OS   | DQ Robotics/Matlab|DQ Robotics/Python |DQ Robotics/C++ |
| -------- | ------- |------- |------- |
| Ubuntu  | :white_check_mark:    | :white_check_mark:   | :white_check_mark:    |
| Windows| :white_check_mark:      | :x:    | Untested     |
| VM Ubuntu on Windows  |  Untested    | :x:    | :x:     |
| MacOS     | Untested    | Untested   | Untested    |


