### PR TITLE
This PR adds some missing bindings solves the bugs reported in #62 and #61

### DIFF
--- a/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
+++ b/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
@@ -20,6 +20,11 @@ Contributors:
 1.  Murilo M. Marinho        (murilomarinho@ieee.org)
         - Initial implementation.
 
+2.  Juan Jose Quiroz Omana (juanjose.quirozomana@manchester.ac.uk)
+        - Added bindings for the following methods
+          set_stepping_mode(), get_object_handle(), get_object_handle()
+          get_joint_{velocities, torques}(), set_joint_target_velocities(),set_joint_torques()
+
 */
 
 #include "../../dqrobotics_module.h"
@@ -89,6 +94,14 @@ void init_DQ_CoppeliaSimInterfaceZMQ_py(py::module& m)
     dqcsinterfacezmq_py.def("get_joint_position",
                            (double (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&))&::DQ_CoppeliaSimInterfaceZMQ::get_joint_positions,
                            "Get joint position");
+
+    dqcsinterfacezmq_py.def("get_object_handle",
+                            (int (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&))&::DQ_CoppeliaSimInterfaceZMQ::get_object_handle,
+                            "gets the object handle from CoppeliaSim.");
+
+    dqcsinterfacezmq_py.def("get_object_handles",
+                            (VectorXd (DQ_CoppeliaSimInterfaceZMQ::*) (const std::vector<std::string>&))&DQ_CoppeliaSimInterfaceZMQ::get_object_handles,
+                            "returns a vector containing the object handles.");
 
     dqcsinterfacezmq_py.def("set_joint_positions",
                            (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::vector<std::string>&, const VectorXd&))&DQ_CoppeliaSimInterfaceZMQ::set_joint_positions,

--- a/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
+++ b/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
@@ -43,7 +43,9 @@ void init_DQ_CoppeliaSimInterfaceZMQ_py(py::module& m)
             > dqcsinterfacezmq_py(m,"DQ_CoppeliaSimInterfaceZMQ");
     dqcsinterfacezmq_py.def(py::init<>());
 
-    dqcsinterfacezmq_py.def("connect",(bool (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const int&, const int&))&DQ_CoppeliaSimInterfaceZMQ::connect,"establishes a connection between the client (your code) and the host (the computer running the CoppeliaSim scene.");
+    dqcsinterfacezmq_py.def("connect",(bool (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const int&, const int&))&DQ_CoppeliaSimInterfaceZMQ::connect,
+                            py::arg("host") = "localhost", py::arg("port") = 23000, py::arg("TIMEOUT_IN_MILISECONDS") = 2000,
+                            "establishes a connection between the client (your code) and the host (the computer running the CoppeliaSim scene.");
     dqcsinterfacezmq_py.def("connect",(bool (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const int&, const int&, const int&))&DQ_CoppeliaSimInterfaceZMQ::connect,"Connects to CoppeliaSim with a given ip.");
 
     dqcsinterfacezmq_py.def("disconnect",    &DQ_CoppeliaSimInterfaceZMQ::disconnect,"Disconnects from CoppeliaSim.");

--- a/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
+++ b/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
@@ -64,7 +64,7 @@ void init_DQ_CoppeliaSimInterfaceZMQ_py(py::module& m)
                            "Gets object translation.");
 
     dqcsinterfacezmq_py.def("set_object_translation",
-                           (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const DQ&, const std::string&))&DQ_CoppeliaSimInterfaceZMQ::set_object_translation,
+                           (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const DQ&))&DQ_CoppeliaSimInterfaceZMQ::set_object_translation,
                            "Sets object translation.");
 
     dqcsinterfacezmq_py.def("get_object_rotation",
@@ -80,7 +80,7 @@ void init_DQ_CoppeliaSimInterfaceZMQ_py(py::module& m)
                            "Gets object pose.");
 
     dqcsinterfacezmq_py.def("set_object_pose",
-                           (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const DQ&, const std::string&))&DQ_CoppeliaSimInterfaceZMQ::set_object_pose,
+                           (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const DQ&))&DQ_CoppeliaSimInterfaceZMQ::set_object_pose,
                            "Sets object pose.");
 
     dqcsinterfacezmq_py.def("get_object_handle",
@@ -102,5 +102,24 @@ void init_DQ_CoppeliaSimInterfaceZMQ_py(py::module& m)
     dqcsinterfacezmq_py.def("get_joint_positions",
                            (VectorXd (DQ_CoppeliaSimInterfaceZMQ::*) (const std::vector<std::string>&))&DQ_CoppeliaSimInterfaceZMQ::get_joint_positions,
                            "Get joint positions");
+
+    dqcsinterfacezmq_py.def("get_joint_velocities",
+                            (VectorXd (DQ_CoppeliaSimInterfaceZMQ::*) (const std::vector<std::string>&))&DQ_CoppeliaSimInterfaceZMQ::get_joint_velocities,
+                            "gets the joint velocities in the CoppeliaSim scene.");
+
+    dqcsinterfacezmq_py.def("set_joint_target_velocities",
+                            (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::vector<std::string>&, const VectorXd&))&DQ_CoppeliaSimInterfaceZMQ::set_joint_target_velocities,
+                            "sets the joint target velocities in the CoppeliaSim scene. "
+                            "This method requires a dynamics enabled scene, and joints in dynamic mode with velocity control mode.");
+
+    dqcsinterfacezmq_py.def("get_joint_torques",
+                            (VectorXd (DQ_CoppeliaSimInterfaceZMQ::*) (const std::vector<std::string>&))&DQ_CoppeliaSimInterfaceZMQ::get_joint_torques,
+                            "gets the joint torques in the CoppeliaSim scene.");
+
+    dqcsinterfacezmq_py.def("set_joint_torques",
+                            (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::vector<std::string>&, const VectorXd&))&DQ_CoppeliaSimInterfaceZMQ::set_joint_torques,
+                            "sets the joint torques in the CoppeliaSim scene. "
+                            "This method requires a dynamics enabled scene, and joints in dynamic mode with force control mode.");
+
 
 }

--- a/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
+++ b/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2019-2024 DQ Robotics Developers
+(C) Copyright 2019-2025 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -38,6 +38,7 @@ void init_DQ_CoppeliaSimInterfaceZMQ_py(py::module& m)
             > dqcsinterfacezmq_py(m,"DQ_CoppeliaSimInterfaceZMQ");
     dqcsinterfacezmq_py.def(py::init<>());
 
+    dqcsinterfacezmq_py.def("connect",(bool (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const int&, const int&))&DQ_CoppeliaSimInterfaceZMQ::connect,"establishes a connection between the client (your code) and the host (the computer running the CoppeliaSim scene.");
     dqcsinterfacezmq_py.def("connect",(bool (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const int&, const int&, const int&))&DQ_CoppeliaSimInterfaceZMQ::connect,"Connects to CoppeliaSim with a given ip.");
 
     dqcsinterfacezmq_py.def("disconnect",    &DQ_CoppeliaSimInterfaceZMQ::disconnect,"Disconnects from CoppeliaSim.");

--- a/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
+++ b/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
@@ -83,18 +83,6 @@ void init_DQ_CoppeliaSimInterfaceZMQ_py(py::module& m)
                            (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const DQ&, const std::string&))&DQ_CoppeliaSimInterfaceZMQ::set_object_pose,
                            "Sets object pose.");
 
-    dqcsinterfacezmq_py.def("set_joint_position",
-                           (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const double&))&::DQ_CoppeliaSimInterfaceZMQ::set_joint_positions,
-                           "Set joint position");
-
-    dqcsinterfacezmq_py.def("set_joint_target_position",
-                           (void (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&, const double&))&DQ_CoppeliaSimInterfaceZMQ::set_joint_target_positions,
-                           "Set joint target position");
-
-    dqcsinterfacezmq_py.def("get_joint_position",
-                           (double (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&))&::DQ_CoppeliaSimInterfaceZMQ::get_joint_positions,
-                           "Get joint position");
-
     dqcsinterfacezmq_py.def("get_object_handle",
                             (int (DQ_CoppeliaSimInterfaceZMQ::*) (const std::string&))&::DQ_CoppeliaSimInterfaceZMQ::get_object_handle,
                             "gets the object handle from CoppeliaSim.");

--- a/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
+++ b/src/interfaces/coppeliasim/DQ_CoppeliaSimInterfaceZMQ_py.cpp
@@ -47,6 +47,7 @@ void init_DQ_CoppeliaSimInterfaceZMQ_py(py::module& m)
     dqcsinterfacezmq_py.def("start_simulation",&DQ_CoppeliaSimInterfaceZMQ::start_simulation,"Start simulation");
     dqcsinterfacezmq_py.def("stop_simulation", &DQ_CoppeliaSimInterfaceZMQ::stop_simulation,"Stops simulation");
 
+    dqcsinterfacezmq_py.def("set_stepping_mode", (void (DQ_CoppeliaSimInterfaceZMQ::*) (const bool&))&DQ_CoppeliaSimInterfaceZMQ::set_stepping_mode, "enables or disables the stepping mode (formerly known as synchronous mode).");
     dqcsinterfacezmq_py.def("set_synchronous", (void (DQ_CoppeliaSimInterfaceZMQ::*) (const bool&))&DQ_CoppeliaSimInterfaceZMQ::set_synchronous, "Sets synchronous mode");
 
     dqcsinterfacezmq_py.def("trigger_next_simulation_step", &DQ_CoppeliaSimInterfaceZMQ::trigger_next_simulation_step, "Sends a synchronization trigger signal to the server.");


### PR DESCRIPTION
![](https://img.shields.io/badge/Tests-developer%20workflow-orange)![](https://img.shields.io/badge/Ubuntu%2024.04.5%20LTS%20(x64)-tested-passing)

Hi @mmmarinho,

This PR adds some missing bindings and solves the bugs reported in #62,  #61, and #60. Specifically, the following methods/features were implemented:

- `connect("localhost", port, TIMEOUT)`  (including default arguments)

- `set_stepping_mode()`,  `get_object_handle()`, ` get_object_handle()`, `get_joint_{velocities, torques}()`, `set_joint_target_velocities()`,  `set_joint_torques()`.

- Removed the methods/bindings `set_joint_position` and `set_joint_target_position` since both are protected methods in the C++ implementation.

- Fixed the signature of the bindings `set_object_pose` (fixing #60), and `set_object_translation`.


Kind regards, 

Juancho

Working example:

I am [working](https://github.com/juanjqo/python-examples/tree/zmq) on a PR to propose the following example to the DQ Robotics.

```python
from dqrobotics import*
from dqrobotics.interfaces.coppeliasim import DQ_CoppeliaSimInterfaceZMQ
from math import sin, cos, pi, pow
import numpy as np
import time

def main() -> None:
    cs = DQ_CoppeliaSimInterfaceZMQ()
    try:
        cs.connect() # or cs.connect("localhost", 23000, 1500)
        cs.set_stepping_mode(True)
        time.sleep(0.1)
        cs.start_simulation()

        # Define some parameters to compute varying-time trajectories
        a = 1
        freq = 0.1
        time_simulation_step = 0.05
        for i in range(300):
            t = i * time_simulation_step
            # Define a varying-time position based on the Lemniscate of Bernoulli
            p = (a * cos(t) / (1 + pow(sin(t),2))) * i_ + (a * sin(t) * cos(t) / (1 + pow(sin(t),2))) * j_

            # Define a varying-time orientation
            r = cos(2 * pi * freq * t) + k_ * sin(2 * pi * freq * t)

            # Built a varying-time unit dual quaternion
            x = r + 0.5 * E_ * p * r

            # Set the object pose in CoppeliaSim
            cs.set_object_pose("/coffee_drone", x)

            # Read the pose of an object in CoppeliaSim to set the pose of
            # another object with a constant offset.
            xread = cs.get_object_pose("/coffee_drone")
            xoffset = 1 + 0.5 * E_ * (0.5 * i_)
            xnew = xread * xoffset
            cs.set_object_pose("/Frame_x", xnew)

            # Set the target position of the first joint of the UMIRobot arm
            target_position = [sin(2 * pi * freq * t)]
            cs.set_joint_target_positions(["UMIRobot/UMIRobot_joint_1"],  target_position)

            # Set the target position of the third joint of the UR5 robot
            cs.set_joint_target_positions(['UR5/link/joint/link/joint'], target_position)

            # Set the target velocity of the first joint of the Franka Emika Panda
            target_velocity = [2 * pi * freq * cos(2 * pi * freq * t)]
            cs.set_joint_target_velocities(['Franka/joint'], target_velocity)

            # Set the torque of the fifth joint of the Franka Emika Panda
            torque = [sin(2 * pi * freq * t)]
            cs.set_joint_torques(['Revolute_joint'], torque)

            # Set the target velocities of the Pioneer wheels
            cs.set_joint_target_velocities(['PioneerP3DX/rightMotor'], [0.1])
            cs.set_joint_target_velocities(['PioneerP3DX/leftMotor'], [0.2])

            # Trigger a simulation step in CoppeliaSim
            cs.trigger_next_simulation_step()

        cs.stop_simulation()

    except (Exception, KeyboardInterrupt) as e:
        print(e)
        cs.stop_simulation()
        pass

if __name__ == "__main__":
    main()

```

### Scene

[DQ_Robotics_lab.zip](https://github.com/user-attachments/files/19075151/DQ_Robotics_lab.zip)

![ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/88db8888-7192-4495-8a59-7b511830f484)



